### PR TITLE
Add `npm install` to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ Google Analytics | 前日までの週間PV数、 前日までの週間直帰率
 - GAS のGoogle謹製CLIツール clasp
     - https://qiita.com/HeRo/items/4e65dcc82783b2766c03
 
-このリポジトリをローカルに持ってきます。
+このリポジトリをローカルに持ってきて、パッケージ群をインストールします。
 
 ```bash
 git clone git@github.com:budougumi0617/blog-kpi-collector.git
 cd blog-kpi-collector
+
+npm install
 ```
 
 


### PR DESCRIPTION
READMEのgit clone 部分に `npm install`コマンドを追加しました。

初期処理として、バージョン管理ツールのコマンドも書いてあったほうが親切だと思ったためです。
`yarn install` でもいいと思いますが、より利用者の多いであろう `npm` にしました。