### PR TITLE
fix 1,000人以上フォロワーがいるとパースできない

### DIFF
--- a/src/twitter.ts
+++ b/src/twitter.ts
@@ -12,13 +12,15 @@ function getTwitterFollowers(accoutName: string): number {
   };
   let html: string = UrlFetchApp.fetch(url, parameters).getContentText("UTF-8");
   // curlで取得したHTMLの中から文字列を取得。その文字列をChrome Dev toolsでこねこねして考えた正規表現。
-  const counts = html.match(/\/followers\">[<>\w\s=/"]*statnum\">(\d+)<\/div>/);
+  const counts = html.match(
+    /\/followers\">[<>\w\s=/"]*statnum\">([\d,]+)<\/div>/
+  );
   if (counts === null) {
-    Logger.log("failed parse twitter");
+    Logger.log("cannot parse twitter follower");
     return -1;
   } else if (counts.length < 2) {
-    Logger.log("failed parse twitter %s", counts);
+    Logger.log("unexpected parse result on twitter %s", counts);
     return -1;
   }
-  return Number(counts[1]);
+  return Number(counts[1].replace(/,/g, ""));
 }


### PR DESCRIPTION
tiwtterのフォロワーが1,000人以上だった場合、パースに失敗していた。

## 原因
カンマが入るとパースに失敗していた。

## 修正方法
`curl` でサンプルとなるHTMLを取得する

```
$ curl https://mobile.twitter.com/Linus_MK| less
```
```html
        <a href="/Linus_MK/followers">
          <div class="statnum">1,250</div>
          <div class="statlabel">フォロワー</div>
        </a>
```
そのあとはChrome Dev Tools上でパースできないか頑張ってみる。
```javascript
s = `<a href="/Linus_MK/followers">
          <div class="statnum">1,250</div>
          <div class="statlabel">フォロワー</div>
        </a>`;
s.match(/\/followers\">[<>\w\s=/"]*statnum\">([\d,]+)<\/div>/);
```