### PR TITLE
設定されていない項目に関してはSlackに通知しない

### DIFF
--- a/src/domain/KPIList.ts
+++ b/src/domain/KPIList.ts
@@ -18,13 +18,56 @@ export class KPIList {
   }
 }
 
-class KPI {
+interface iKPI {
+  /**
+   * valueを取得する。
+   */
+  getValue(): string;
+  /**
+   * Slackに通知するためのFieldsを返却する。
+   * anyではなく、ガッチリ定義してもよいが、そのためにライブラリを追加したり定義するのは大変なので、anyで見送る。
+   */
+  toSlackFields(): any;
+}
+
+export class KPI implements iKPI {
   constructor(
     private description: string,
     private value: string
   ) { }
 
-  public getValue() {
+  public static Factory = class {
+    public static date(value: string): KPI {
+      return new KPI("Date", value);
+    }
+
+    public static twitterFollower(value: string): KPI {
+      return new KPI("Twitter Follower", value);
+    }
+
+    public static weeklyPV(value: string): KPI {
+      return new KPI("WeeklyPV", value);
+    }
+
+    public static weeklyBounceRate(value: string): KPI {
+      return new KPI("Weekly Bounce Rate", value);
+    }
+
+    public static bookmarks(value: string): KPI {
+      return new KPI("Bookmarks", value);
+    }
+
+    public static subscribers(value: string): KPI {
+      return new KPI("Subscribers", value);
+    }
+
+    public static stars(value: string): KPI {
+      return new KPI("Stars", value);
+    }
+  }
+
+
+  public getValue(): string {
     return this.value;
   }
 
@@ -37,58 +80,3 @@ class KPI {
   }
 }
 
-export class KPIDate extends KPI {
-  constructor(
-    value: string
-  ) {
-    super("Date", value);
-  }
-}
-
-export class KPITwitterFollower extends KPI {
-  constructor(
-    value: string
-  ) {
-    super("Twitter Follower", value);
-  }
-}
-
-export class KPIWeeklyPV extends KPI {
-  constructor(
-    value: string
-  ) {
-    super("WeeklyPV", value);
-  }
-}
-
-export class KPIWeeklyBounceRate extends KPI {
-  constructor(
-    value: string
-  ) {
-    super("Weekly Bounce Rate", value);
-  }
-}
-
-export class KPIBookmarks extends KPI {
-  constructor(
-    value: string
-  ) {
-    super("Bookmarks", value);
-  }
-}
-
-export class KPISubscribers extends KPI {
-  constructor(
-    value: string
-  ) {
-    super("Subscribers", value);
-  }
-}
-
-export class KPIStars extends KPI {
-  constructor(
-    value: string
-  ) {
-    super("Stars", value);
-  }
-}

--- a/src/domain/KPIList.ts
+++ b/src/domain/KPIList.ts
@@ -8,13 +8,13 @@ export class KPIList {
   }
 
   public getSpreadSheetArray(): Array<string> {
-    return this.kpiList.map(kpi => kpi.getValue);
+    return this.kpiList.map(kpi => kpi.getValue());
   }
 
   public getSlackArray(): any {
     return this.kpiList
-      .filter(kpi => (kpi.getValue === "-1"))
-      .map(kpi => kpi.toSlackFields);
+      .filter(kpi => kpi.getValue() !== "-1")
+      .map(kpi => kpi.toSlackFields());
   }
 }
 
@@ -45,4 +45,50 @@ export class KPIDate extends KPI {
   }
 }
 
-// TODO: いっぱい以下にデータを作る
+export class KPITwitterFollower extends KPI {
+  constructor(
+    value: string
+  ) {
+    super("Twitter Follower", value);
+  }
+}
+
+export class KPIWeeklyPV extends KPI {
+  constructor(
+    value: string
+  ) {
+    super("WeeklyPV", value);
+  }
+}
+
+export class KPIWeeklyBounceRate extends KPI {
+  constructor(
+    value: string
+  ) {
+    super("Weekly Bounce Rate", value);
+  }
+}
+
+export class KPIBookmarks extends KPI {
+  constructor(
+    value: string
+  ) {
+    super("Bookmarks", value);
+  }
+}
+
+export class KPISubscribers extends KPI {
+  constructor(
+    value: string
+  ) {
+    super("Subscribers", value);
+  }
+}
+
+export class KPIStars extends KPI {
+  constructor(
+    value: string
+  ) {
+    super("Stars", value);
+  }
+}

--- a/src/domain/KPIList.ts
+++ b/src/domain/KPIList.ts
@@ -1,0 +1,48 @@
+export class KPIList {
+  private kpiList: Array<KPI>;
+  constructor() {
+    this.kpiList = [];
+  }
+  public add(kpi: KPI): void {
+    this.kpiList.push(kpi);
+  }
+
+  public getSpreadSheetArray(): Array<string> {
+    return this.kpiList.map(kpi => kpi.getValue);
+  }
+
+  public getSlackArray(): any {
+    return this.kpiList
+      .filter(kpi => (kpi.getValue === "-1"))
+      .map(kpi => kpi.toSlackFields);
+  }
+}
+
+class KPI {
+  constructor(
+    private description: string,
+    private value: string
+  ) { }
+
+  public getValue() {
+    return this.value;
+  }
+
+  public toSlackFields(): any {
+    return {
+      "title": this.description,
+      "value": this.value,
+      "short": "true"
+    }
+  }
+}
+
+export class KPIDate extends KPI {
+  constructor(
+    value: string
+  ) {
+    super("Date", value);
+  }
+}
+
+// TODO: いっぱい以下にデータを作る

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { KPIDate, KPITwitterFollower, KPIWeeklyPV, KPIWeeklyBounceRate, KPIBookmarks, KPISubscribers, KPIStars, KPIList } from './domain/KPIList';
+import { KPI, KPIList } from './domain/KPIList';
 
 // main
 // 紐付けられたスプレットシートにKPIを記録していく関数
@@ -77,13 +77,13 @@ function main() {
   }
 
   const kpiList = new KPIList();
-  kpiList.add(new KPIDate(today));
-  kpiList.add(new KPITwitterFollower(followers.toString()));
-  kpiList.add(new KPIWeeklyPV(pv.toString()));
-  kpiList.add(new KPIWeeklyBounceRate(bounceRate.toString()));
-  kpiList.add(new KPIBookmarks(bookmarks.toString()));
-  kpiList.add(new KPISubscribers(numOfSubscribers.toString()));
-  kpiList.add(new KPIStars(stars.toString()));
+  kpiList.add(KPI.Factory.date(today));
+  kpiList.add(KPI.Factory.twitterFollower(followers.toString()));
+  kpiList.add(KPI.Factory.weeklyPV(pv.toString()));
+  kpiList.add(KPI.Factory.weeklyBounceRate(bounceRate.toString()));
+  kpiList.add(KPI.Factory.bookmarks(bookmarks.toString()));
+  kpiList.add(KPI.Factory.subscribers(numOfSubscribers.toString()));
+  kpiList.add(KPI.Factory.stars(stars.toString()));
 
   // スプレッドシートに追記する
   console.log(kpiList.getSpreadSheetArray());

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { KPIDate, KPIList } from './domain/KPIList';
+import { KPIDate, KPITwitterFollower, KPIWeeklyPV, KPIWeeklyBounceRate, KPIBookmarks, KPISubscribers, KPIStars, KPIList } from './domain/KPIList';
 
 // main
 // 紐付けられたスプレットシートにKPIを記録していく関数
@@ -78,29 +78,23 @@ function main() {
 
   const kpiList = new KPIList();
   kpiList.add(new KPIDate(today));
-  console.log(kpiList);
-  console.log(kpiList.getSpreadSheetArray());
-  // TODO: この辺をいい感じに追記していく
+  kpiList.add(new KPITwitterFollower(followers.toString()));
+  kpiList.add(new KPIWeeklyPV(pv.toString()));
+  kpiList.add(new KPIWeeklyBounceRate(bounceRate.toString()));
+  kpiList.add(new KPIBookmarks(bookmarks.toString()));
+  kpiList.add(new KPISubscribers(numOfSubscribers.toString()));
+  kpiList.add(new KPIStars(stars.toString()));
 
   // スプレッドシートに追記する
-  const appendData: Array<any> = [
-    today,
-    followers,
-    pv,
-    bounceRate,
-    bookmarks,
-    numOfSubscribers,
-    stars
-  ];
-  console.log(appendData);
-  sheet.appendRow(appendData);
+  console.log(kpiList.getSpreadSheetArray());
+  sheet.appendRow(kpiList.getSpreadSheetArray());
 
   // Slackへの通知を行う。 
   const slackUrl = PropertiesService.getScriptProperties().getProperty(
     "SLACK_URL"
   );
   if (slackUrl != null) {
-    slackNotification(slackUrl, appendData);
+    slackNotification(slackUrl, kpiList);
   } else {
     console.log('Slack通知URLは取得しませんでした');
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+import { KPIDate, KPIList } from './domain/KPIList';
+
 // main
 // 紐付けられたスプレットシートにKPIを記録していく関数
 // 使い方はREADME参照のこと
@@ -73,6 +75,12 @@ function main() {
   } else {
     console.log("読者数・スター数は取得しませんでした");
   }
+
+  const kpiList = new KPIList();
+  kpiList.add(new KPIDate(today));
+  console.log(kpiList);
+  console.log(kpiList.getSpreadSheetArray());
+  // TODO: この辺をいい感じに追記していく
 
   // スプレッドシートに追記する
   const appendData: Array<any> = [

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -1,4 +1,6 @@
-function slackNotification(slackUrl: string, value: Array<any>) {
+import { KPIList } from "./domain/KPIList";
+
+function slackNotification(slackUrl: string, value: KPIList) {
   const options: any = {
     'method': 'post',
     'headers': { 'Content-type': 'application/x-www-form-urlencoded' },
@@ -9,43 +11,7 @@ function slackNotification(slackUrl: string, value: Array<any>) {
           'color': '#36a64f',
           'title': '今週のブログKPIを取得しました！',
           'title_link': 'https://docs.google.com/spreadsheets/d/' + SpreadsheetApp.getActiveSpreadsheet().getId(),
-          "fields": [
-            {
-              "title": "Date",
-              "value": value[0],
-              "short": "true"
-            },
-            {
-              "title": "Twitter Follower",
-              "value": value[1],
-              "short": "true"
-            },
-            {
-              "title": "WeeklyPV",
-              "value": value[2],
-              "short": "true"
-            },
-            {
-              "title": "Weekly Bounce Rate",
-              "value": value[3],
-              "short": "true"
-            },
-            {
-              "title": "Bookmarks",
-              "value": value[4],
-              "short": "true"
-            },
-            {
-              "title": "Subscribers",
-              "value": value[5],
-              "short": "true"
-            },
-            {
-              "title": "Stars",
-              "value": value[6],
-              "short": "true"
-            }
-          ]
+          "fields": value.getSlackArray(),
         }
       ]
     })


### PR DESCRIPTION
Fixes #15 

また、「-1」の場合通知しない、というのをクラスに処理を寄せた。
この辺のTypescriptのベストプラクティスはわからないので、Rejectしてもらっても大丈夫です。

# 機能案
- [x] SpreadSheetに書き込む内容は変更しない
- [x] 「-1」の項目はSlackに通知しない

# テスト
## 条件1：TwitterとSlack通知URLのみ設定する

期待値：
- SpreadSheetには日付とTwitterの値を追加する。他は-1を書き込む。
- Slackには日付とTwitterの値のみ通知する

![201](https://user-images.githubusercontent.com/30658134/97101239-132a7600-16df-11eb-81a2-0f62d4308d5d.png)

## 条件2：すべての項目を設定する
- SpreadSheetにはすべての項目を設定する
- Slackにはすべての項目を通知する

![202](https://user-images.githubusercontent.com/30658134/97101242-16bdfd00-16df-11eb-9e96-7dcfecfcc9cb.png)

# 備考
下記のプロパティを読み込む処理はまだ解消されていないようです。(10月25日16:30)
なので、動作確認する際は、修正する必要があります。

```
PropertiesService.getScriptProperties().getProperty(”string”)
```

