### PR TITLE
Claspをローカルに導入せずにDockerで導入できるようにする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM node:latest
+WORKDIR /usr/src/app
+RUN npm install @google/clasp -g

--- a/README.md
+++ b/README.md
@@ -160,6 +160,32 @@ $ git pull
 $ clasp push
 ```
 
+# Docker環境を利用する場合
+
+ローカルに直接Claspを導入せずにDockerを使用する場合は、こちらの手順を参考にしてください。
+
+```bash
+# コンテナへのログイン
+docker-compose run clasp bash
+
+cd /usr/src/app
+# Googleへのログイン
+clasp login --no-localhost
+# npm install
+npm install
+# KPIシート作成
+clasp create --title "KPI Sheet" --type sheets --rootDir ./src
+# .clasp.jsonの移動
+mv ./src/.clasp.json ./.clasp.json
+clasp pull
+clasp push
+```
+
+<!--
+参考URL：
+https://zenn.dev/marusho/scraps/3579309aabf5eb
+ -->
+
 # 要望など
 Issueでお願いします。
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+services:
+  clasp:
+    build: .
+    tty: true
+    stdin_open: true
+    volumes:
+      - ./:/usr/src/app


### PR DESCRIPTION
DockerでClaspをインストールして、Dockerからアップロードできるような環境を作成しました。