### PR TITLE
直接「スクリプトのプロパティ」を使えるように設定箇所を切り出す

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,26 +123,13 @@ https://8bees.net/gas%e3%81%ae%e3%83%97%e3%83%ad%e3%83%91%e3%83%86%e3%82%a3%e8%a
   
 ```ts
 namespace CustomProperties {
-  const SHEET_NAME: string = "";
-  const TWITTER_NAME: string = "";
-  const VIEW_ID: string = "";
-  const BLOG_URL: string = "";
-  const HATENA_BLOG: boolean = false;
-  const SLACK_URL: string = "";
+  const SHEET_NAME = "";
+  const TWITTER_NAME = "";
+  const VIEW_ID = "";
+  const BLOG_URL = "";
+  const HATENA_BLOG = false;
+  const SLACK_URL = "";
 }
-```
-
-なお、こちらのプロパティ値を万が一にでもgitで管理したくないという場合は、次のコマンドを使用をオススメします。
-
-```bash
-# コミットしたくないファイルを無視する設定
-# https://qiita.com/usamik26/items/56d0d3ba7a1300625f92
-
-# コミット対象から外す
-git update-index --skip-worktree src/customProperties.ts
-
-# 外したファイルをコミット対象に含める
-# git update-index --no-skip-worktree src/customProperties.ts
 ```
 
 # Google Analyticsとの連携方法

--- a/README.md
+++ b/README.md
@@ -112,6 +112,39 @@ https://8bees.net/gas%e3%81%ae%e3%83%97%e3%83%ad%e3%83%91%e3%83%86%e3%82%a3%e8%a
 4. 設定するプロパティの名前と値を入力していく
 ![スクリプトのプロパティ](./img/properties.png)
 
+### 直接プロパティを入力する場合
+
+スクリプトのプロパティが「旧エディタ」でないとできなくなっていますので、直接値を設定する方法を取る場合の設定箇所を記載します。
+  
+- 対象ファイル
+  - CustomProperties.ts
+
+次の定数（const）に「スクリプトのプロパティ」を設定してください。
+  
+```ts
+namespace CustomProperties {
+  const SHEET_NAME: string = "";
+  const TWITTER_NAME: string = "";
+  const VIEW_ID: string = "";
+  const BLOG_URL: string = "";
+  const HATENA_BLOG: boolean = false;
+  const SLACK_URL: string = "";
+}
+```
+
+なお、こちらのプロパティ値を万が一にでもgitで管理したくないという場合は、次のコマンドを使用をオススメします。
+
+```bash
+# コミットしたくないファイルを無視する設定
+# https://qiita.com/usamik26/items/56d0d3ba7a1300625f92
+
+# コミット対象から外す
+git update-index --skip-worktree src/customProperties.ts
+
+# 外したファイルをコミット対象に含める
+# git update-index --no-skip-worktree src/customProperties.ts
+```
+
 # Google Analyticsとの連携方法
 Google Analyticsとの連携には`GA_VIEW_ID`の他にAnalytics APIを有効にする必要があります。
 

--- a/src/customProperties.ts
+++ b/src/customProperties.ts
@@ -1,38 +1,39 @@
 /**
  * 個別のプロパティを取得および設定するためのモジュール.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace CustomProperties {
   /**
    * 集計したいシート名
    * 例：シート1
    */
-  const SHEET_NAME: string = "";
+  const SHEET_NAME = "";
   /**
    * TwitterID
    * 例： budougumi0617
    */
-  const TWITTER_NAME: string = "";
+  const TWITTER_NAME = "";
   /**
    * GAのID.
    * 例：ga:000000000
    */
-  const VIEW_ID: string = "";
+  const VIEW_ID = "";
   /**
    * ブログのURL.
    * 例：https://budougumi0617.github.io/
    */
-  const BLOG_URL: string = "";
+  const BLOG_URL = "";
   /**
    * trueにすると、集計したいブログのURLがはてなブログの場合。はてなブログ読者数とはてなスター数を取得する
    * 
    * 例：false
    */
-  const HATENA_BLOG: boolean = false;
+  const HATENA_BLOG = false;
   /**
    * SlackのIncommingHook
    * 例：https://hooks.slack.com/services/TAH1RHKEW/B01BXA1PYBC/JQ5aIRrqTnAAAAAAAAAAAAA
    */
-  const SLACK_URL: string = "";
+  const SLACK_URL = "";
 
   /**
    * "SHEET_NAME"にはDrive上に作成したスプレットシートのシート名を入力しておくこと。

--- a/src/customProperties.ts
+++ b/src/customProperties.ts
@@ -1,0 +1,129 @@
+/**
+ * 個別のプロパティを取得および設定するためのモジュール.
+ */
+namespace CustomProperties {
+  /**
+   * 集計したいシート名
+   * 例：シート1
+   */
+  const SHEET_NAME: string = "";
+  /**
+   * TwitterID
+   * 例： budougumi0617
+   */
+  const TWITTER_NAME: string = "";
+  /**
+   * GAのID.
+   * 例：ga:000000000
+   */
+  const VIEW_ID: string = "";
+  /**
+   * ブログのURL.
+   * 例：https://budougumi0617.github.io/
+   */
+  const BLOG_URL: string = "";
+  /**
+   * trueにすると、集計したいブログのURLがはてなブログの場合。はてなブログ読者数とはてなスター数を取得する
+   * 
+   * 例：false
+   */
+  const HATENA_BLOG: boolean = false;
+  /**
+   * SlackのIncommingHook
+   * 例：https://hooks.slack.com/services/TAH1RHKEW/B01BXA1PYBC/JQ5aIRrqTnAAAAAAAAAAAAA
+   */
+  const SLACK_URL: string = "";
+
+  /**
+   * "SHEET_NAME"にはDrive上に作成したスプレットシートのシート名を入力しておくこと。
+   * 未入力の場合はデフォルトの"シート1"に書き込まれる。
+   * 例: シート1
+   **/
+  export function getSheetName(): string {
+    if (SHEET_NAME != "") {
+      return SHEET_NAME;
+    }
+
+    const sheetName = PropertiesService.getScriptProperties().getProperty(
+      "SHEET_NAME"
+    );
+    if (sheetName == null || sheetName.length === 0) {
+      return "シート1";
+    }
+    return sheetName;
+  }
+
+  /**
+   * Twitterのフォロワー情報を取得する
+   * TWITTER_NAMEにはアカウント名を入力しておくこと(@は不要)
+   **/
+  export function getTwitterName(): string | null {
+    if (TWITTER_NAME != "") {
+      return TWITTER_NAME;
+    }
+
+    return PropertiesService.getScriptProperties().getProperty(
+      "TWITTER_NAME"
+    );
+  }
+
+  /**
+   * Gooogle Analyticsから実行した日の前日から過去7日間のPV数と直帰数を取得する。
+   * GA_VIEW_IDには"ga:"から始まるIDを入力しておくこと。
+   * IDの取得方法は以下の通り
+   * 1. 以下のURLを開く
+   *    - https://ga-dev-tools.appspot.com/query-explorer/#report-start
+   * 2. Select Viewで集計したいデータを選択する
+   * 3. Set the query parametersのidsに自動入力される"ga:000000000"というIDをGA_VIEW_IDとする
+   **/
+  export function getViewID(): string | null {
+    if (VIEW_ID != "") {
+      return VIEW_ID;
+    }
+
+    return PropertiesService.getScriptProperties().getProperty(
+      "GA_VIEW_ID"
+    );
+  }
+
+  /**
+   *「指定した url とそれ以下のパスの url」に対するはてなブックマークの合計数の合計を取得する
+   * BLOG_URLには自分のサイトのURLを入力しておくこと。
+   * 例: https://budougumi0617.github.io/
+   **/
+  export function getBlogUrl(): string | null {
+    if (BLOG_URL != "") {
+      return BLOG_URL;
+    }
+
+    return PropertiesService.getScriptProperties().getProperty(
+      "BLOG_URL"
+    );
+  }
+
+  /**
+   * 「HATENA_BLOGがtrue」だった場合、「指定した url のブログ」に対する読者数・スター数を取得する
+   **/
+  export function getHatenaBlog(): string | null {
+    if (HATENA_BLOG) {
+      return "true";
+    }
+
+    return PropertiesService.getScriptProperties().getProperty(
+      "HATENA_BLOG"
+    );
+  }
+
+  /**
+   * 通知先のURLを取得する
+   */
+  export function getSlackUrl(): string | null {
+    if (SLACK_URL != "") {
+      return SLACK_URL;
+    }
+
+    return PropertiesService.getScriptProperties().getProperty(
+      "SLACK_URL"
+    );
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,12 +9,7 @@ function main() {
   // "SHEET_NAME"にはDrive上に作成したスプレットシートのシート名を入力しておくこと。
   // 未入力の場合はデフォルトの"シート1"に書き込まれる。
   // 例: シート1
-  let sheetName = PropertiesService.getScriptProperties().getProperty(
-    "SHEET_NAME"
-  );
-  if (sheetName == null || sheetName.length === 0) {
-    sheetName = "シート1";
-  }
+  const sheetName = CustomProperties.getSheetName();
   const sheet = spreadsheet.getSheetByName(sheetName);
 
   const today = Utilities.formatDate(new Date(), "JST", "yyyy/MM/dd");
@@ -22,9 +17,7 @@ function main() {
   // Twitterのフォロワー情報を取得する
   // TWITTER_NAMEにはアカウント名を入力しておくこと(@は不要)
   let followers = -1;
-  const twitterName = PropertiesService.getScriptProperties().getProperty(
-    "TWITTER_NAME"
-  );
+  const twitterName = CustomProperties.getTwitterName();
   if (twitterName != null) {
     followers = twitter.getTwitterFollowers(twitterName);
   } else {
@@ -38,9 +31,7 @@ function main() {
   //    - https://ga-dev-tools.appspot.com/query-explorer/#report-start
   // 2. Select Viewで集計したいデータを選択する
   // 3. Set the query parametersのidsに自動入力される"ga:000000000"というIDをGA_VIEW_IDとする
-  const viewID = PropertiesService.getScriptProperties().getProperty(
-    "GA_VIEW_ID"
-  );
+  const viewID = CustomProperties.getViewID();
   let pv = -1;
   let bounceRate = -1;
   if (viewID != null) {
@@ -55,9 +46,7 @@ function main() {
   // BLOG_URLには自分のサイトのURLを入力しておくこと。
   // 例: https://budougumi0617.github.io/
   let bookmarks = -1;
-  const blogUrl = PropertiesService.getScriptProperties().getProperty(
-    "BLOG_URL"
-  );
+  const blogUrl = CustomProperties.getBlogUrl();
   if (blogUrl != null) {
     bookmarks = hatena.getBookmarkCount(blogUrl);
   } else {
@@ -67,9 +56,7 @@ function main() {
   // 「HATENA_BLOGがtrue」だった場合、「指定した url のブログ」に対する読者数・スター数を取得する
   let numOfSubscribers = -1;
   let stars = -1;
-  const hatenaBlog = PropertiesService.getScriptProperties().getProperty(
-    "HATENA_BLOG"
-  );
+  const hatenaBlog = CustomProperties.getHatenaBlog();
   if (hatenaBlog === "true" && blogUrl != null) {
     numOfSubscribers = hatena.getNumOfSubscribers(blogUrl);
     stars = hatena.getStarCount(blogUrl);
@@ -91,9 +78,7 @@ function main() {
   sheet?.appendRow(kpiList.getSpreadSheetArray());
 
   // Slackへの通知を行う。
-  const slackUrl = PropertiesService.getScriptProperties().getProperty(
-    "SLACK_URL"
-  );
+  const slackUrl = CustomProperties.getSlackUrl();
   if (slackUrl != null) {
     slackNotification(slackUrl, kpiList);
   } else {


### PR DESCRIPTION
# 意図
現状、「スクリプトのプロパティ」は「旧エディタ」でしか設定できません。
  
「旧エディタ」で使用できるうちは問題ないのですが、「新エディタ」で設定できない以上はdeprecatedされる可能性は0ではありません。

そのため、設定箇所をまとめて分かりやすく設定できるようにしました。

# 仕様

次の値を優先して使用します。

1. 定数(const)に設定している値
2. スクリプトのプロパティ
